### PR TITLE
Custom logger

### DIFF
--- a/lib/server_health_check.rb
+++ b/lib/server_health_check.rb
@@ -2,8 +2,10 @@ require "server_health_check/version"
 
 class ServerHealthCheck
   OK = 'OK'.freeze
+  attr_reader :logger
 
-  def initialize
+  def initialize(options = {})
+    @logger = options[:logger]
     @results = {}
   end
 
@@ -32,7 +34,9 @@ class ServerHealthCheck
   end
 
   def aws_s3!(bucket = nil)
-    bucket = Aws::S3::Bucket.new(bucket)
+    options = {}
+    options[:logger] = logger if logger
+    bucket = Aws::S3::Bucket.new(bucket, options)
     if bucket.exists?
       @results[:S3] = OK
       true
@@ -43,7 +47,9 @@ class ServerHealthCheck
   end
 
   def aws_creds!
-    aws = Aws::S3::Client.new
+    options = {}
+    options[:logger] = logger if logger
+    aws = Aws::S3::Client.new(options)
     begin
       aws.list_buckets
       @results[:AWS] = OK

--- a/lib/server_health_check.rb
+++ b/lib/server_health_check.rb
@@ -63,8 +63,8 @@ class ServerHealthCheck
       @results[name.to_sym] = "Failed"
       false
     end
-    rescue => e
-      @results[name.to_sym] = e.to_s
+  rescue => e
+    @results[name.to_sym] = e.to_s
   end
 
   def ok?

--- a/spec/server_health_check_spec.rb
+++ b/spec/server_health_check_spec.rb
@@ -13,10 +13,11 @@ end
 module Aws
   class S3
     class Bucket
-      def initialize(options = nil); end
+      def initialize(bucket_name, options = nil); end
     end
 
     class Client
+      def initialize(options = nil); end
     end
 
     class Errors


### PR DESCRIPTION
This is part of a bigger plan to use a different logger for health checks that for other site requests.

Since health checks happen every 30 seconds, they fill up the logs with information that is most likely not relevant to anyone scanning the logs.